### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish-to-docker-hub.yml
+++ b/.github/workflows/publish-to-docker-hub.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build and publish to docker hub
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           # Bu alanı `dockerHubId/projeAdi:versiyon` olacak şekilde güncelleyin.
           name: cihangll/aspnetcore-serilog-seq-docker-githubaction


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore